### PR TITLE
Generalize type signatures for "angelic binds"

### DIFF
--- a/Control/IMonad/Restrict.hs
+++ b/Control/IMonad/Restrict.hs
@@ -85,7 +85,10 @@ returnR :: (IMonad m) => a -> m (a := i) i
 returnR = returnI . V
 
 {-| A flipped 'bindI' that restricts the intermediate and final index.
-    Called \"angelic bind\" in Conor McBride's paper.
+    Called \"angelic bind\" in Conor McBride's paper.  The type of this
+    function has the following specialization:
+
+    @(!>=) :: IMonad m => m (a := j) i -> (a -> m (b := k) j) -> m (b := k) i@
 -}
 (!>=) :: (IMonad m) => m (a := j) i -> (a -> m b j) -> m b i
 m !>= f = bindI (\(V a) -> f a) m
@@ -106,11 +109,19 @@ fmapR f m = m !>= returnR . f
 (<.>) :: (IMonad m) => m ((a -> b) := j) i -> m (a := k) j -> m (b := k) i
 mf <.> mx = mf !>= \f -> f <!> mx
 
--- | A 'bindI' that restricts the intermediate and final index
+{-| A 'bindI' that restricts the intermediate and final index.  The type of this
+    function has the following specialization:
+
+    @(=\<!) :: IMonad m => (a -> m (b := k) j) -> m (a := j) i -> m (b := k) i@
+-}
 (=<!) :: (IMonad m) => (a -> m b j) -> m (a := j) i -> m b i
 (=<!) = flip (!>=)
 
--- | Sequence two indexed monads
+{-| Sequence two indexed monads.  The type of this function has the
+    following specialization:
+
+    @(!>) :: IMonad m => m (a := j) i -> m (b := k) j -> m (b := k) i@
+-}
 (!>) :: (IMonad m) => m (a := j) i -> m b j -> m b i
 m1 !> m2 = m1 !>= \_ -> m2
 
@@ -118,6 +129,10 @@ m1 !> m2 = m1 !>= \_ -> m2
     Composition of restricted Kleisli arrows
 
     This is equivalent to ('>>>') from @Control.Category@.
+
+    The type of this function has the following specialization:
+
+    @IMonad m => (a -> m (b:= j) i) -> (b -> m (c := k) j) -> (a -> m (c := k) i)@
 -}
 (>!>) :: (IMonad m) =>
     (a -> m (b := j) i) -> (b -> m c j) -> (a -> m c i)
@@ -127,12 +142,20 @@ f >!> g = \x -> f x !>= g
     Composition of restricted Kleisli arrows
 
     This is equivalent to ('<<<') from @Control.Category@.
+
+    The type of this function has the following specialization:
+
+    @(\<!\<) :: IMonad m => (b -> m (c := k) j) -> (a -> m (b := j) i) -> a -> m (c := k) i@
 -}
 (<!<) :: (IMonad m) =>
     (b -> m c j) -> (a -> m (b := j) i) -> (a -> m c i)
 f <!< g = \x -> f =<! g x
 
--- | 'joinR' joins two monad layers into one
+{-| 'joinR' joins two monad layers into one. The type of this
+    function has the following specialization:
+     
+    @joinR :: IMonad m => m (m (a := k) j := j) i -> m (a := k) i@
+-}
 joinR :: (IMonad m) => m (m a j := j) i -> m a i
 joinR m = m !>= id
 


### PR DESCRIPTION
I think the types of the "angelic binds" can be generalized.  The final return type does not need to be restricted.  Please check you agree with me because I only learned about indexed monads yesterday!
