### PR TITLE
Relax Cabal-Version to >= 1.10 and add Setup.hs (cabal check warning)

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/index-core.cabal
+++ b/index-core.cabal
@@ -1,6 +1,6 @@
 Name: index-core
 Version: 1.0.2
-Cabal-Version: >=1.14.0
+Cabal-Version: >=1.10
 Build-Type: Simple
 License: BSD3
 License-File: LICENSE


### PR DESCRIPTION
`Cabal-Version: >=1.10` is a good default to use, `cabal check` warns if it needs to be constrained. This makes the library buildable on a default GHC-7.0 install.
