### PR TITLE
Fix build on GHC 7.10

### DIFF
--- a/Control/IMonad/Core.hs
+++ b/Control/IMonad/Core.hs
@@ -72,7 +72,7 @@ class (IFunctor m) => IMonad m where
 
 -- | An infix 'bindI' with arguments flipped
 (?>=) :: (IMonad m) => m a i -> (a :-> m b) -> m b i
-(?>=) = flip bindI
+m ?>= k = bindI k m
 
 {-|
     Composition of indexed Kleisli arrows


### PR DESCRIPTION
The issue with (?>=) is impredicative polymorsphism. Avoiding `flip`
fixes the error. See http://stackoverflow.com/questions/29712710/polymorphic-flip-fails-in-7-10