### PR TITLE
Enable PolyKinds

### DIFF
--- a/Control/Category/Index.hs
+++ b/Control/Category/Index.hs
@@ -7,7 +7,7 @@
 --
 --   Sometimes you may also need the @Rank2Types@ extension.
 
-{-# LANGUAGE TypeOperators, Rank2Types #-}
+{-# LANGUAGE TypeOperators, Rank2Types, PolyKinds #-}
 
 module Control.Category.Index (
     -- * Index-Preserving Functions

--- a/Control/IMonad/Core.hs
+++ b/Control/IMonad/Core.hs
@@ -3,7 +3,7 @@
     indexed counterparts to 'Functor' and 'Monad' from @Control.Monad@.
 -}
 
-{-# LANGUAGE Rank2Types, TypeOperators #-}
+{-# LANGUAGE Rank2Types, TypeOperators, PolyKinds #-}
 
 module Control.IMonad.Core (
     -- * Indexed Monads
@@ -31,7 +31,7 @@ infixl 1 ?>=
 
     Indexed monads generalize the traditional approach to parametrizing the
     initial and final states of ordinary monads.  The 'IMonad' class does not
-    require specifying a concrete index of kind @*@ for the intermediate or
+    require specifying a concrete index of kind @k@ for the intermediate or
     final state of the 'bindI' operation, permitting operations which may end in
     multiple possible states.
 -}

--- a/Control/IMonad/Restrict.hs
+++ b/Control/IMonad/Restrict.hs
@@ -4,7 +4,7 @@
     (':=') type constructor which restricts the index of the return value.
 -}
 
-{-# LANGUAGE TypeOperators, GADTs, Rank2Types #-}
+{-# LANGUAGE TypeOperators, GADTs, Rank2Types, PolyKinds #-}
 
 module Control.IMonad.Restrict (
     -- * Restriction

--- a/Control/IMonad/Trans.hs
+++ b/Control/IMonad/Trans.hs
@@ -3,7 +3,7 @@
     the @transformers@ package.
 -}
 
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeOperators, PolyKinds #-}
 
 module Control.IMonad.Trans (
     -- * Monad Transformers


### PR DESCRIPTION
This change enables the kind of the indexes to be polymorphic, whereas previously they were fixed to kind `*`. It's a backwards compatible change.
