### PR TITLE
Also enable PolyKinds in Control.IMonad.Do module

### DIFF
--- a/Control/IMonad/Do.hs
+++ b/Control/IMonad/Do.hs
@@ -11,7 +11,7 @@
 -- @NoImplicitPrelude@ extension, otherwise the Prelude's @Monad@ bindings would
 -- conflict with these bindings.
 
-{-# LANGUAGE GADTs, Rank2Types, TypeOperators #-}
+{-# LANGUAGE GADTs, Rank2Types, TypeOperators, PolyKinds #-}
 
 module Control.IMonad.Do (
     -- * Modules


### PR DESCRIPTION
@Gabriel439 as I commented on #7, this module also benefits from having `PolyKinds` enabled. I forgot to enable it the first time because I wasn't using this module so I didn't get an error from the compiler :)